### PR TITLE
Enable ssh to /boot/ssh for treehouse-builder script

### DIFF
--- a/treehouse-builder
+++ b/treehouse-builder
@@ -62,6 +62,7 @@ ADD_REPO_KEYS=(
 # Example: CUSTOM_COMMAND="curl http://some.domain/script.sh | bash -i ; rm -f /some/file"
 CUSTOM_COMMAND="\
     update-alternatives --set editor /usr/bin/vim.basic;
+    touch /boot/ssh;
 #    docker pull dogi/rpi-couchdb    
 "
 

--- a/treehouse-builder
+++ b/treehouse-builder
@@ -62,7 +62,7 @@ ADD_REPO_KEYS=(
 # Example: CUSTOM_COMMAND="curl http://some.domain/script.sh | bash -i ; rm -f /some/file"
 CUSTOM_COMMAND="\
     update-alternatives --set editor /usr/bin/vim.basic;
-    touch /boot/ssh;
+    sudo touch /boot/ssh;
 #    docker pull dogi/rpi-couchdb    
 "
 


### PR DESCRIPTION
Requires reboot of RPI3 in order to turn automatically turn on ssh for the image. /boot/ssh file will automatically be removed by the system if everything works according to plan. A warning will be issued in Raspbian stating that "SSH is enabled and the default password for the 'pi' user has not been changed. This is a security risk - please login as the 'pi' user and run Raspberry Pi Configuration to set a new password.