### PR TITLE
Fix for entering chroot and added latest raspbian urls+sha1 to treehouse-builder

### DIFF
--- a/treehouse-builder
+++ b/treehouse-builder
@@ -16,7 +16,6 @@
 # Raspbian
 RASPBIAN_URL=http://people.sugarlabs.org/ignacio/2017-04-10-raspbian-jessie.zip
 RASPBIAN_SHA1=6d7b11bb3d64524203edf6c80c499456fb5fef53
-
 #RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-01-10/2017-01-11-raspbian-jessie.zip
 #RASPBIAN_SHA1=f987935e3e99366a6f1bf0d60a7a83fe3edb013c
 

--- a/treehouse-builder
+++ b/treehouse-builder
@@ -14,16 +14,8 @@
 # ADD_REPO_KEYS=()
 
 # Raspbian
-# STABLE
 RASPBIAN_URL=http://people.sugarlabs.org/ignacio/2017-04-10-raspbian-jessie.zip
 RASPBIAN_SHA1=6d7b11bb3d64524203edf6c80c499456fb5fef53
-
-# OTHER
-#RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-07-05/2017-07-05-raspbian-jessie.zip
-#RASPBIAN_SHA1=e1edd4d26090b3e67a66939fa77eeb656de8a2c5
-
-#RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-06-23/2017-06-21-raspbian-jessie.zip
-#RASPBIAN_SHA1=82a4ecfaadbef4cfb8625f673b5f7b91c24c8e32
 
 #RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-01-10/2017-01-11-raspbian-jessie.zip
 #RASPBIAN_SHA1=f987935e3e99366a6f1bf0d60a7a83fe3edb013c

--- a/treehouse-builder
+++ b/treehouse-builder
@@ -14,8 +14,17 @@
 # ADD_REPO_KEYS=()
 
 # Raspbian
+# STABLE
 RASPBIAN_URL=http://people.sugarlabs.org/ignacio/2017-04-10-raspbian-jessie.zip
 RASPBIAN_SHA1=6d7b11bb3d64524203edf6c80c499456fb5fef53
+
+# OTHER
+#RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-07-05/2017-07-05-raspbian-jessie.zip
+#RASPBIAN_SHA1=e1edd4d26090b3e67a66939fa77eeb656de8a2c5
+
+#RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-06-23/2017-06-21-raspbian-jessie.zip
+#RASPBIAN_SHA1=82a4ecfaadbef4cfb8625f673b5f7b91c24c8e32
+
 #RASPBIAN_URL=http://downloads.raspberrypi.org/raspbian/images/raspbian-2017-01-10/2017-01-11-raspbian-jessie.zip
 #RASPBIAN_SHA1=f987935e3e99366a6f1bf0d60a7a83fe3edb013c
 
@@ -192,7 +201,9 @@ _modify_image
 
 if [[ "$1" == "--chroot" ]] ; then
     echo "Starting interactive Shell in image chroot"
+    _prepare_chroot
     chroot mnt/img_root bash -i
+    _cleanup_chroot
     exit 0
 elif [[ "$1" == "--noninteractive" ]] ; then
     :


### PR DESCRIPTION
Kept 2017-04-10-raspbian-jessie as default image but also added the two urls with their sha1 for testing.

As for the chroot error below - it is now fixed and should now run without any errors. Thanks to 0xdaf.

`qemu: uncaught target signal 4 (Illegal instruction) - core dumped
/home/ole/treehouse-builder/treehouse-builder: line 234: 15424 Illegal instruction (core dumped) chroot mnt/img_root bash -i`
