### PR TITLE
update get_ssh_keys.py (issue #49)

### DIFF
--- a/get_ssh_keys.py
+++ b/get_ssh_keys.py
@@ -6,7 +6,7 @@ import json
 import urllib2
 
 # Retrieve a list of public members using gitHub API
-api = 'https://api.github.com/orgs/open-learning-exchange/members'
+api = 'https://api.github.com/orgs/open-learning-exchange/members?&per_page=100'
 json_data = json.load(urllib2.urlopen(api))
 members = []
 for member in json_data:


### PR DESCRIPTION
- Added `?&per_page=100` to the url so we could retrieve up to 100 members at once
